### PR TITLE
feat: add sign_message tool (Issue #4)

### DIFF
--- a/e2e/fixtures/chat-mock.ts
+++ b/e2e/fixtures/chat-mock.ts
@@ -178,6 +178,41 @@ export function sendPaymentStream(
   ].join("");
 }
 
+/** Build SSE body for "sign message" scenario */
+export function signMessageStream(
+  message = "Hello CDP!",
+  address = WALLETS.myAgent.address
+): string {
+  const toolCallId = "call_sign_1";
+  const textId = "text_1";
+  const mockSignature = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab1c";
+  const abbrevSig = `${mockSignature.slice(0, 10)}...${mockSignature.slice(-8)}`;
+  const abbrevAddr = `${address.slice(0, 6)}...${address.slice(-4)}`;
+  return [
+    msgStart(),
+    stepStart(),
+    toolInputStart(toolCallId, "sign_message"),
+    toolInputAvailable(toolCallId, "sign_message", { message }),
+    toolOutputAvailable(toolCallId, {
+      success: true,
+      walletAddress: address,
+      message,
+      signature: mockSignature,
+    }),
+    stepFinish(),
+    stepStart(),
+    textStart(textId),
+    textDelta(
+      textId,
+      `Signed with \`${abbrevAddr}\`:\n\nMessage: "${message}"\nSignature: \`${abbrevSig}\``
+    ),
+    textEnd(textId),
+    stepFinish(),
+    msgFinish(),
+    sseDone(),
+  ].join("");
+}
+
 /** Build SSE body for "what is my wallet address?" — plain text response */
 export function walletInfoStream(
   address = WALLETS.myAgent.address
@@ -230,6 +265,7 @@ type ChatScenario =
   | "faucet-usdc"
   | "send-eth"
   | "send-usdc"
+  | "sign-message"
   | "general-response"
   | "slow-response";
 
@@ -242,6 +278,7 @@ const scenarioBuilders: Record<ChatScenario, () => string> = {
     sendPaymentStream(WALLETS.bob.address, "0.00001", "eth"),
   "send-usdc": () =>
     sendPaymentStream(WALLETS.bob.address, "1", "usdc"),
+  "sign-message": () => signMessageStream(),
   "general-response": () =>
     generalResponseStream(
       "I'm PayAgent, your AI payment assistant on Base Sepolia. How can I help?"

--- a/e2e/tests/10-chat-sign-message.spec.ts
+++ b/e2e/tests/10-chat-sign-message.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from "@playwright/test";
+import { mockApiRoutes, mockLogin3Session } from "../fixtures/api-mocks";
+import { mockChatRoute } from "../fixtures/chat-mock";
+
+test.describe("Section 10: Chat Sign Message", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLogin3Session(page);
+    await mockApiRoutes(page);
+  });
+
+  test("10-1: sign a message via chat", async ({ page }) => {
+    await mockChatRoute(page, "sign-message");
+    await page.goto("/");
+
+    // Ask to sign a message
+    await page.getByTestId("chat-input").fill("Sign the message: Hello CDP!");
+    await page.getByTestId("chat-submit").click();
+
+    // Tool indicator for sign_message
+    await expect(page.getByTestId("tool-indicator-sign_message")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("tool-checkmark")).toBeVisible({ timeout: 10000 });
+
+    // Response should contain the signature and the message
+    await expect(page.getByText(/Signature:/).first()).toBeVisible();
+    await expect(page.getByText("0xabcdef12...7890ab1c")).toBeVisible();
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -28,6 +28,7 @@ const TOOL_NAMES = [
   "check_balance",
   "request_faucet",
   "send_payment",
+  "sign_message",
 ];
 
 function snakeToPascalTool(snake: string): string {
@@ -176,6 +177,7 @@ Tools available:
 - check_balance: Check ETH and USDC balance of a wallet
 - send_payment: Send ETH or USDC from the user's agent wallet to any address
 - request_faucet: Get testnet ETH or USDC from the faucet
+- sign_message: Sign an arbitrary text message with the user's agent wallet (EIP-191)
 
 Guidelines:
 - IMPORTANT: Call only ONE tool at a time. Never make parallel/simultaneous tool calls. If you need multiple operations (e.g., request both ETH and USDC), call them one at a time sequentially.
@@ -315,6 +317,27 @@ export async function POST(req: Request) {
             token,
           });
           return result;
+        },
+      },
+
+      sign_message: {
+        description:
+          "Sign an arbitrary text message with the user's agent wallet (EIP-191 signature)",
+        inputSchema: z.object({
+          message: z.string().describe("The text message to sign"),
+        }),
+        execute: async ({ message }: { message: string }) => {
+          const cdp = getCdpClient();
+          const { signature } = await cdp.evm.signMessage({
+            address: user.agentWalletAddress as `0x${string}`,
+            message,
+          });
+          return {
+            success: true,
+            walletAddress: user.agentWalletAddress,
+            message,
+            signature,
+          };
         },
       },
     };


### PR DESCRIPTION
## Summary
- Add `sign_message` tool to AI chat agent for EIP-191 message signing
- Uses CDP SDK `evm.signMessage()` with user's auto-created agent wallet
- Returns wallet address, original message, and hex signature

## Changes
- **`src/app/api/chat/route.ts`**: Add `sign_message` tool definition, update TOOL_NAMES and system prompt
- **`e2e/fixtures/chat-mock.ts`**: Add `signMessageStream` builder and `sign-message` scenario
- **`e2e/tests/10-chat-sign-message.spec.ts`**: E2E test verifying tool indicator and signature display

## Test plan
- [x] `pnpm tsc --noEmit` — PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm test` — 21 unit tests PASS
- [x] `pnpm test:e2e` — 25 E2E tests PASS (24 existing + 1 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)