### PR TITLE
feat: add buy_product tool with x402-style payment

### DIFF
--- a/e2e/fixtures/chat-mock.ts
+++ b/e2e/fixtures/chat-mock.ts
@@ -213,6 +213,48 @@ export function signMessageStream(
   ].join("");
 }
 
+/** Build SSE body for "buy product" scenario (x402-style payment) */
+export function buyProductStream(): string {
+  const toolCallId = "call_buy_1";
+  const textId = "text_1";
+  const txHash = "0xabc123def456789012345678901234567890123456789012345678901234abcd";
+  return [
+    msgStart(),
+    stepStart(),
+    toolInputStart(toolCallId, "buy_product"),
+    toolInputAvailable(toolCallId, "buy_product", {}),
+    toolOutputAvailable(toolCallId, {
+      success: true,
+      product: "Premium Weather Data",
+      data: {
+        location: "Base Sepolia Network",
+        temperature: "23°C",
+        condition: "Partly Cloudy",
+        humidity: "62%",
+        wind: "12 km/h NW",
+        forecast: "Clear skies expected over the next 24 hours",
+      },
+      payment: {
+        paid_wei: "10000000000000",
+        tx_hash: txHash,
+        explorer: `https://sepolia.basescan.org/tx/${txHash}`,
+      },
+      explorerUrl: `https://sepolia.basescan.org/tx/${txHash}`,
+    }),
+    stepFinish(),
+    stepStart(),
+    textStart(textId),
+    textDelta(
+      textId,
+      `Purchased **Premium Weather Data** for 0.00001 ETH!\n\n- Temperature: 23°C\n- Condition: Partly Cloudy\n- Humidity: 62%\n\n[View transaction](https://sepolia.basescan.org/tx/${txHash})`
+    ),
+    textEnd(textId),
+    stepFinish(),
+    msgFinish(),
+    sseDone(),
+  ].join("");
+}
+
 /** Build SSE body for "what is my wallet address?" — plain text response */
 export function walletInfoStream(
   address = WALLETS.myAgent.address
@@ -266,6 +308,7 @@ type ChatScenario =
   | "send-eth"
   | "send-usdc"
   | "sign-message"
+  | "buy-product"
   | "general-response"
   | "slow-response";
 
@@ -279,6 +322,7 @@ const scenarioBuilders: Record<ChatScenario, () => string> = {
   "send-usdc": () =>
     sendPaymentStream(WALLETS.bob.address, "1", "usdc"),
   "sign-message": () => signMessageStream(),
+  "buy-product": () => buyProductStream(),
   "general-response": () =>
     generalResponseStream(
       "I'm PayAgent, your AI payment assistant on Base Sepolia. How can I help?"

--- a/e2e/tests/11-chat-buy-product.spec.ts
+++ b/e2e/tests/11-chat-buy-product.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from "@playwright/test";
+import { mockApiRoutes, mockLogin3Session } from "../fixtures/api-mocks";
+import { mockChatRoute } from "../fixtures/chat-mock";
+
+test.describe("Section 11: Chat Buy Product", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLogin3Session(page);
+    await mockApiRoutes(page);
+  });
+
+  test("11-1: purchase premium weather data via chat", async ({ page }) => {
+    await mockChatRoute(page, "buy-product");
+    await page.goto("/");
+
+    // Ask to buy the product
+    await page.getByTestId("chat-input").fill("Buy the premium weather data");
+    await page.getByTestId("chat-submit").click();
+
+    // Tool indicator for buy_product
+    await expect(page.getByTestId("tool-indicator-buy_product")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("tool-checkmark")).toBeVisible({ timeout: 10000 });
+
+    // Response should contain weather data and transaction link
+    await expect(page.getByText("Premium Weather Data").first()).toBeVisible();
+    await expect(page.getByText("23°C")).toBeVisible();
+    await expect(page.getByText(/View transaction/)).toBeVisible();
+  });
+});

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,12 +1,18 @@
 import { createOpenAI } from "@ai-sdk/openai";
 import { streamText, convertToModelMessages, stepCountIs } from "ai";
 import { z } from "zod";
-import { isAddress } from "viem";
+import { isAddress, parseEther } from "viem";
 import { getCdpClient } from "@/lib/cdp";
 import { publicClient } from "@/lib/viem";
 import { getBalances } from "@/lib/balance";
 import { executeTransfer } from "@/lib/transfer";
 import { authenticateRequest } from "@/lib/auth";
+import {
+  PAYMENT_REQUIREMENTS,
+  MERCHANT_ADDRESS,
+  verifyPayment,
+  buildProduct,
+} from "@/lib/shop";
 
 export const maxDuration = 60;
 
@@ -29,6 +35,7 @@ const TOOL_NAMES = [
   "request_faucet",
   "send_payment",
   "sign_message",
+  "buy_product",
 ];
 
 function snakeToPascalTool(snake: string): string {
@@ -178,6 +185,7 @@ Tools available:
 - send_payment: Send ETH or USDC from the user's agent wallet to any address
 - request_faucet: Get testnet ETH or USDC from the faucet
 - sign_message: Sign an arbitrary text message with the user's agent wallet (EIP-191)
+- buy_product: Purchase premium weather data using x402-style ETH payment (costs ${PAYMENT_REQUIREMENTS.price_eth} ETH)
 
 Guidelines:
 - IMPORTANT: Call only ONE tool at a time. Never make parallel/simultaneous tool calls. If you need multiple operations (e.g., request both ETH and USDC), call them one at a time sequentially.
@@ -337,6 +345,49 @@ export async function POST(req: Request) {
             walletAddress: user.agentWalletAddress,
             message,
             signature,
+          };
+        },
+      },
+
+      buy_product: {
+        description: `Purchase premium weather data by sending ${PAYMENT_REQUIREMENTS.price_eth} ETH to the merchant on Base Sepolia (x402-style payment)`,
+        inputSchema: z.object({}),
+        execute: async () => {
+          const cdp = getCdpClient();
+          const account = await cdp.evm.getOrCreateAccount({
+            name: user.agentWalletName,
+          });
+          const baseAccount = await account.useNetwork("base-sepolia");
+
+          // Send ETH to merchant
+          const { transactionHash } = await baseAccount.sendTransaction({
+            transaction: {
+              to: MERCHANT_ADDRESS,
+              value: parseEther(PAYMENT_REQUIREMENTS.price_eth),
+            },
+          });
+
+          // Wait for confirmation
+          await publicClient.waitForTransactionReceipt({
+            hash: transactionHash,
+          });
+
+          // Verify payment and get product
+          const verification = await verifyPayment(transactionHash);
+          if (!verification.valid) {
+            return {
+              success: false,
+              error: verification.reason ?? "Payment verification failed",
+              transactionHash,
+              explorerUrl: `https://sepolia.basescan.org/tx/${transactionHash}`,
+            };
+          }
+
+          const product = buildProduct(transactionHash, verification.value);
+          return {
+            success: true,
+            ...product,
+            explorerUrl: `https://sepolia.basescan.org/tx/${transactionHash}`,
           };
         },
       },

--- a/src/app/api/shop/route.ts
+++ b/src/app/api/shop/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { isHex } from "viem";
+import {
+  PAYMENT_REQUIREMENTS,
+  MERCHANT_ADDRESS,
+  verifyPayment,
+  buildProduct,
+} from "@/lib/shop";
+
+export const maxDuration = 30;
+
+// GET /api/shop — x402-style merchant endpoint
+//   No X-Payment-Tx header → 402 + payment requirements
+//   With X-Payment-Tx header → verify payment → 200 + product data
+export async function GET(request: Request) {
+  const paymentTx = request.headers.get("x-payment-tx");
+
+  // No payment: return 402 with requirements
+  if (!paymentTx) {
+    return NextResponse.json(
+      {
+        status: 402,
+        message: "Payment Required",
+        requirements: PAYMENT_REQUIREMENTS,
+      },
+      {
+        status: 402,
+        headers: {
+          "X-Payment-Recipient": MERCHANT_ADDRESS,
+          "X-Payment-Amount-Wei": PAYMENT_REQUIREMENTS.price_wei,
+          "X-Payment-Chain-Id": "84532",
+        },
+      }
+    );
+  }
+
+  // Validate tx hash format
+  if (!isHex(paymentTx) || paymentTx.length !== 66) {
+    return NextResponse.json(
+      {
+        status: 402,
+        message: "Payment Required",
+        error: "Invalid transaction hash format",
+        requirements: PAYMENT_REQUIREMENTS,
+      },
+      { status: 402 }
+    );
+  }
+
+  // Verify payment on-chain
+  const result = await verifyPayment(paymentTx as `0x${string}`);
+  if (!result.valid) {
+    return NextResponse.json(
+      {
+        status: 402,
+        message: "Payment Required",
+        error: result.reason,
+        requirements: PAYMENT_REQUIREMENTS,
+      },
+      { status: 402 }
+    );
+  }
+
+  // Payment verified — return product
+  const product = buildProduct(paymentTx, result.value);
+  return NextResponse.json({
+    success: true,
+    data: product,
+  });
+}

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -73,7 +73,7 @@ export default function ChatView({
       if (processedToolsRef.current.has(toolKey)) return;
       processedToolsRef.current.add(toolKey);
 
-      if (toolName === "check_balance" || toolName === "request_faucet" || toolName === "send_payment") {
+      if (toolName === "check_balance" || toolName === "request_faucet" || toolName === "send_payment" || toolName === "buy_product") {
         onRefreshBalance();
       }
     },

--- a/src/lib/shop.ts
+++ b/src/lib/shop.ts
@@ -1,0 +1,81 @@
+import { publicClient } from "./viem";
+
+/**
+ * Simplified x402 merchant configuration.
+ * The merchant address receives ETH payments for product purchases.
+ */
+export const MERCHANT_ADDRESS =
+  "0x557925d2C45793a678F94D4B638251E537Fa6dB8" as const;
+
+const PRICE_WEI = 10_000_000_000_000n; // 0.00001 ETH
+
+export const PAYMENT_REQUIREMENTS = {
+  protocol: "x402-simplified",
+  description: "Premium weather data for Base Sepolia",
+  price_eth: "0.00001",
+  price_wei: PRICE_WEI.toString(),
+  recipient: MERCHANT_ADDRESS,
+  chain: "Base Sepolia (84532)",
+  instructions:
+    "Send exactly 0.00001 ETH to the recipient address on Base Sepolia, then provide the transaction hash.",
+};
+
+/**
+ * Verify an on-chain ETH payment to the merchant.
+ */
+export async function verifyPayment(
+  txHash: `0x${string}`
+): Promise<{ valid: boolean; reason?: string; value?: bigint }> {
+  try {
+    const receipt = await publicClient.getTransactionReceipt({ hash: txHash });
+    if (receipt.status !== "success") {
+      return { valid: false, reason: "Transaction reverted" };
+    }
+
+    const tx = await publicClient.getTransaction({ hash: txHash });
+    if (tx.to?.toLowerCase() !== MERCHANT_ADDRESS.toLowerCase()) {
+      return {
+        valid: false,
+        reason: `Wrong recipient: expected ${MERCHANT_ADDRESS}, got ${tx.to}`,
+      };
+    }
+    if (tx.value < PRICE_WEI) {
+      return {
+        valid: false,
+        reason: `Insufficient payment: expected >= ${PRICE_WEI} wei, got ${tx.value} wei`,
+      };
+    }
+
+    return { valid: true, value: tx.value };
+  } catch (error) {
+    return {
+      valid: false,
+      reason:
+        error instanceof Error
+          ? error.message
+          : "Failed to verify transaction",
+    };
+  }
+}
+
+/**
+ * Build the product data returned after a verified payment.
+ */
+export function buildProduct(txHash: string, value?: bigint) {
+  return {
+    product: "Premium Weather Data",
+    data: {
+      location: "Base Sepolia Network",
+      temperature: "23°C",
+      condition: "Partly Cloudy",
+      humidity: "62%",
+      wind: "12 km/h NW",
+      forecast: "Clear skies expected over the next 24 hours",
+    },
+    payment: {
+      paid_wei: value?.toString() ?? PRICE_WEI.toString(),
+      tx_hash: txHash,
+      explorer: `https://sepolia.basescan.org/tx/${txHash}`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `GET /api/shop` merchant endpoint with HTTP 402 Payment Required flow (x402 protocol)
- Adds `buy_product` chat tool: sends 0.00001 ETH to merchant, verifies on-chain, returns premium weather data
- Creates `src/lib/shop.ts` with payment verification and product builder utilities
- Adds E2E test (Section 11) covering the full purchase flow via chat

## Files changed
- `src/lib/shop.ts` — Merchant config, `verifyPayment()`, `buildProduct()`
- `src/app/api/shop/route.ts` — GET endpoint with 402/200 flow
- `src/app/api/chat/route.ts` — `buy_product` tool added to TOOL_NAMES and tools
- `src/components/ChatView.tsx` — Balance refresh on buy_product completion
- `e2e/fixtures/chat-mock.ts` — `buyProductStream` scenario
- `e2e/tests/11-chat-buy-product.spec.ts` — E2E test

## Test plan
- [x] `pnpm tsc --noEmit` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` — 21 unit tests pass
- [x] `pnpm test:e2e` — 26 E2E tests pass (including new test 11)

🤖 Generated with [Claude Code](https://claude.com/claude-code)