### PR TITLE
feat: integrate Stripe card payments with 3DS support

### DIFF
--- a/e2e/fixtures/api-mocks.ts
+++ b/e2e/fixtures/api-mocks.ts
@@ -170,5 +170,43 @@ export async function mockApiRoutes(
     });
   });
 
+  // POST /api/stripe/setup — return mock checkout URL
+  await page.route("**/api/stripe/setup", async (route, request) => {
+    if (request.method() !== "POST") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        url: "https://checkout.stripe.com/mock-session",
+      }),
+    });
+  });
+
+  // GET /api/stripe/payment-status — return mock card info
+  await page.route("**/api/stripe/payment-status*", async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.fallback();
+      return;
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: true,
+        has_payment_method: true,
+        card_summary: {
+          brand: "visa",
+          last4: "4242",
+          exp_month: 12,
+          exp_year: 2027,
+        },
+      }),
+    });
+  });
+
   return { balances };
 }

--- a/e2e/fixtures/chat-mock.ts
+++ b/e2e/fixtures/chat-mock.ts
@@ -213,6 +213,47 @@ export function signMessageStream(
   ].join("");
 }
 
+/** Build SSE body for "buy with Stripe" scenario */
+export function buyWithStripeStream(): string {
+  const toolCallId = "call_stripe_buy_1";
+  const textId = "text_1";
+  return [
+    msgStart(),
+    stepStart(),
+    toolInputStart(toolCallId, "buy_with_stripe"),
+    toolInputAvailable(toolCallId, "buy_with_stripe", {
+      stripe_customer_id: "cus_mock123",
+    }),
+    toolOutputAvailable(toolCallId, {
+      success: true,
+      amount_charged: "$1.00 USD",
+      payment_intent_id: "pi_mock456",
+      product: "Premium AI Market Report",
+      data: {
+        report_id: "RPT-MOCK1234",
+        title: "AI Market Analysis Report",
+        executive_summary:
+          "Strong bullish momentum detected across tech and DeFi sectors.",
+        key_findings: [
+          "AI infrastructure spending up 42% YoY",
+          "Base ecosystem TVL growing at record pace",
+        ],
+      },
+    }),
+    stepFinish(),
+    stepStart(),
+    textStart(textId),
+    textDelta(
+      textId,
+      `Purchased **Premium AI Market Report** for $1.00!\n\nKey findings:\n- AI infrastructure spending up 42% YoY\n- Base ecosystem TVL growing at record pace`
+    ),
+    textEnd(textId),
+    stepFinish(),
+    msgFinish(),
+    sseDone(),
+  ].join("");
+}
+
 /** Build SSE body for "buy product" scenario (x402-style payment) */
 export function buyProductStream(): string {
   const toolCallId = "call_buy_1";
@@ -309,6 +350,7 @@ type ChatScenario =
   | "send-usdc"
   | "sign-message"
   | "buy-product"
+  | "buy-with-stripe"
   | "general-response"
   | "slow-response";
 
@@ -323,6 +365,7 @@ const scenarioBuilders: Record<ChatScenario, () => string> = {
     sendPaymentStream(WALLETS.bob.address, "1", "usdc"),
   "sign-message": () => signMessageStream(),
   "buy-product": () => buyProductStream(),
+  "buy-with-stripe": () => buyWithStripeStream(),
   "general-response": () =>
     generalResponseStream(
       "I'm PayAgent, your AI payment assistant on Base Sepolia. How can I help?"

--- a/e2e/tests/12-chat-buy-stripe.spec.ts
+++ b/e2e/tests/12-chat-buy-stripe.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from "@playwright/test";
+import { mockApiRoutes, mockLogin3Session } from "../fixtures/api-mocks";
+import { mockChatRoute } from "../fixtures/chat-mock";
+
+test.describe("Section 12: Chat Buy with Stripe", () => {
+  test.beforeEach(async ({ page }) => {
+    await mockLogin3Session(page);
+    await mockApiRoutes(page);
+  });
+
+  test("12-1: shows card info when stripe customer ID is saved", async ({ page }) => {
+    // Pre-seed stripe customer ID in localStorage
+    await page.addInitScript(() => {
+      localStorage.setItem("stripe_customer_id", "cus_mock123");
+    });
+    await mockChatRoute(page, "general-response");
+    await page.goto("/");
+
+    // Card info should be visible on welcome screen
+    await expect(page.getByTestId("card-info")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText("visa ****4242")).toBeVisible();
+  });
+
+  test("12-2: shows add card button when no stripe customer", async ({ page }) => {
+    await mockChatRoute(page, "general-response");
+    await page.goto("/");
+
+    // Add card button should be visible
+    await expect(page.getByTestId("add-card-button")).toBeVisible({ timeout: 10000 });
+  });
+
+  test("12-3: purchase AI market report with Stripe via chat", async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem("stripe_customer_id", "cus_mock123");
+    });
+    await mockChatRoute(page, "buy-with-stripe");
+    await page.goto("/");
+
+    // Ask to buy with Stripe
+    await page.getByTestId("chat-input").fill("Buy the AI market report with my card");
+    await page.getByTestId("chat-submit").click();
+
+    // Tool indicator for buy_with_stripe
+    await expect(page.getByTestId("tool-indicator-buy_with_stripe")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("tool-checkmark")).toBeVisible({ timeout: 10000 });
+
+    // Response should contain report data
+    await expect(page.getByText("Premium AI Market Report").first()).toBeVisible();
+    await expect(page.getByText("$1.00")).toBeVisible();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "@ai-sdk/react": "^3.0.106",
     "@coinbase/cdp-sdk": "^1.44.1",
     "@rainbow-me/rainbowkit": "^2.2.10",
+    "@stripe/stripe-js": "^8.9.0",
     "@tanstack/react-query": "^5.90.21",
     "ai": "^6.0.104",
     "next": "^16.1.6",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "stripe": "^20.4.0",
     "viem": "^2.46.3",
     "wagmi": "^2.19.5",
     "zod": "3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@rainbow-me/rainbowkit':
         specifier: ^2.2.10
         version: 2.2.10(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(wagmi@2.19.5(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.21(react@19.2.4))(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.4)(typescript@5.9.3)(utf-8-validate@5.0.10)(viem@2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))(zod@3.25.76))
+      '@stripe/stripe-js':
+        specifier: ^8.9.0
+        version: 8.9.0
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@19.2.4)
@@ -35,6 +38,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      stripe:
+        specifier: ^20.4.0
+        version: 20.4.0(@types/node@25.3.2)
       viem:
         specifier: ^2.46.3
         version: 2.46.3(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -1420,6 +1426,10 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@stripe/stripe-js@8.9.0':
+    resolution: {integrity: sha512-OJkXvUI5GAc56QdiSRimQDvWYEqn475J+oj8RzRtFTCPtkJNO2TWW619oDY+nn1ExR+2tCVTQuRQBbR4dRugww==}
+    engines: {node: '>=12.16'}
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
@@ -3920,6 +3930,15 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  stripe@20.4.0:
+    resolution: {integrity: sha512-F/aN1IQ9vHmlyLNi3DkiIbyzQb6gyBG0uYFd/VrEVQSc9BLtlgknPUx0EvzZdBMRLFuRaPFIFd7Mxwtg7Pbwzw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   styled-jsx@5.1.6:
     resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
     engines: {node: '>= 12.0.0'}
@@ -6206,6 +6225,8 @@ snapshots:
       - utf-8-validate
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@stripe/stripe-js@8.9.0': {}
 
   '@swc/helpers@0.5.15':
     dependencies:
@@ -9467,6 +9488,10 @@ snapshots:
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
+
+  stripe@20.4.0(@types/node@25.3.2):
+    optionalDependencies:
+      '@types/node': 25.3.2
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -13,6 +13,13 @@ import {
   verifyPayment,
   buildProduct,
 } from "@/lib/shop";
+import {
+  STRIPE_PRODUCT,
+  chargeCustomer,
+  verifyPaymentIntent,
+  buildStripeProduct,
+  getDefaultPaymentMethod,
+} from "@/lib/stripe";
 
 export const maxDuration = 60;
 
@@ -36,6 +43,9 @@ const TOOL_NAMES = [
   "send_payment",
   "sign_message",
   "buy_product",
+  "buy_with_stripe",
+  "verify_stripe_payment",
+  "stripe_check_setup",
 ];
 
 function snakeToPascalTool(snake: string): string {
@@ -164,7 +174,8 @@ function isValidAddress(addr: string): addr is `0x${string}` {
 function buildSystemPrompt(
   agentWalletName: string,
   agentWalletAddress: string,
-  connectedAddress: string | undefined
+  connectedAddress: string | undefined,
+  stripeCustomerId: string | undefined
 ): string {
   let walletSection = "";
   if (connectedAddress) {
@@ -172,11 +183,19 @@ function buildSystemPrompt(
   }
   walletSection += `Agent wallet: "${agentWalletName}" (${agentWalletAddress})`;
 
+  const stripeSection = stripeCustomerId
+    ? `The user has a Stripe payment method set up. Their Stripe Customer ID is: ${stripeCustomerId}. When they ask to buy something with a card, use this customer ID directly with buy_with_stripe.`
+    : `The user has NOT set up a Stripe payment method yet. If they want to buy with a card, tell them to click the "+ Add Card" button first.`;
+
   return `You are PayAgent, an AI payment assistant on Base Sepolia testnet.
 
 === USER'S WALLETS (you know this) ===
 ${walletSection}
 === END WALLETS ===
+
+=== STRIPE ===
+${stripeSection}
+=== END STRIPE ===
 
 When the user asks "what wallets do I have", "my address", "my wallet", or similar, answer using the wallet info above. Never say you don't have this info.
 
@@ -186,6 +205,9 @@ Tools available:
 - request_faucet: Get testnet ETH or USDC from the faucet
 - sign_message: Sign an arbitrary text message with the user's agent wallet (EIP-191)
 - buy_product: Purchase premium weather data using x402-style ETH payment (costs ${PAYMENT_REQUIREMENTS.price_eth} ETH)
+- buy_with_stripe: Purchase a premium AI market report ($${(STRIPE_PRODUCT.price_cents / 100).toFixed(2)}) using the user's saved Stripe card
+- verify_stripe_payment: Verify a Stripe payment after 3D Secure authentication
+- stripe_check_setup: Check if the user has a saved Stripe payment method
 
 Guidelines:
 - IMPORTANT: Call only ONE tool at a time. Never make parallel/simultaneous tool calls. If you need multiple operations (e.g., request both ETH and USDC), call them one at a time sequentially.
@@ -209,7 +231,7 @@ export async function POST(req: Request) {
   }
 
   try {
-    const { messages: uiMessages, connectedAddress } = await req.json();
+    const { messages: uiMessages, connectedAddress, stripeCustomerId } = await req.json();
     const modelMessages = await convertToModelMessages(uiMessages);
 
     const sanitizedConnectedAddress =
@@ -217,10 +239,16 @@ export async function POST(req: Request) {
         ? connectedAddress
         : undefined;
 
+    const sanitizedStripeCustomerId =
+      typeof stripeCustomerId === "string" && stripeCustomerId.startsWith("cus_")
+        ? stripeCustomerId
+        : undefined;
+
     const systemPrompt = buildSystemPrompt(
       user.agentWalletName,
       user.agentWalletAddress,
-      sanitizedConnectedAddress
+      sanitizedConnectedAddress,
+      sanitizedStripeCustomerId
     );
 
     // Inject wallet context into the first user message as a hidden prefix,
@@ -230,6 +258,9 @@ export async function POST(req: Request) {
       walletContext += `[Context: User's connected browser wallet is ${sanitizedConnectedAddress}] `;
     }
     walletContext += `[Context: User's agent wallet is "${user.agentWalletName}" at ${user.agentWalletAddress}] `;
+    if (sanitizedStripeCustomerId) {
+      walletContext += `[Context: User's Stripe Customer ID is ${sanitizedStripeCustomerId}] `;
+    }
     if (walletContext && modelMessages.length > 0) {
       const first = modelMessages[0];
       if (first.role === "user" && Array.isArray(first.content)) {
@@ -388,6 +419,119 @@ export async function POST(req: Request) {
             success: true,
             ...product,
             explorerUrl: `https://sepolia.basescan.org/tx/${transactionHash}`,
+          };
+        },
+      },
+
+      buy_with_stripe: {
+        description: `Buy a premium AI market report ($${(STRIPE_PRODUCT.price_cents / 100).toFixed(2)}) using the user's saved Stripe card. If 3D Secure is required, returns a client_secret for popup confirmation.`,
+        inputSchema: z.object({
+          stripe_customer_id: z
+            .string()
+            .describe("Stripe Customer ID (cus_...)"),
+        }),
+        execute: async ({
+          stripe_customer_id,
+        }: {
+          stripe_customer_id: string;
+        }) => {
+          const result = await chargeCustomer(
+            stripe_customer_id,
+            STRIPE_PRODUCT.price_cents,
+            STRIPE_PRODUCT.name
+          );
+
+          if (!result.success) {
+            if ("requires_3ds" in result && result.requires_3ds) {
+              return {
+                success: false,
+                requires_stripe_action: true,
+                payment_intent_id: result.payment_intent_id,
+                client_secret: result.client_secret,
+                message: result.reason,
+                instruction:
+                  "A 3D Secure popup will appear for you to complete authentication.",
+              };
+            }
+            return { success: false, error: result.reason };
+          }
+
+          const product = buildStripeProduct(
+            result.payment_intent_id,
+            STRIPE_PRODUCT.price_cents
+          );
+          return {
+            success: true,
+            amount_charged: `$${(STRIPE_PRODUCT.price_cents / 100).toFixed(2)} USD`,
+            payment_intent_id: result.payment_intent_id,
+            ...product,
+          };
+        },
+      },
+
+      verify_stripe_payment: {
+        description:
+          "Verify a Stripe payment after the user completed 3D Secure authentication in a popup",
+        inputSchema: z.object({
+          payment_intent_id: z
+            .string()
+            .describe("Stripe PaymentIntent ID (pi_...)"),
+        }),
+        execute: async ({
+          payment_intent_id,
+        }: {
+          payment_intent_id: string;
+        }) => {
+          const { success, reason } =
+            await verifyPaymentIntent(payment_intent_id);
+          if (!success) {
+            return { success: false, error: reason };
+          }
+          const product = buildStripeProduct(
+            payment_intent_id,
+            STRIPE_PRODUCT.price_cents
+          );
+          return {
+            success: true,
+            amount_charged: `$${(STRIPE_PRODUCT.price_cents / 100).toFixed(2)} USD`,
+            payment_intent_id,
+            ...product,
+          };
+        },
+      },
+
+      stripe_check_setup: {
+        description:
+          "Check if the user has a saved Stripe payment method ready for autonomous payments",
+        inputSchema: z.object({
+          stripe_customer_id: z
+            .string()
+            .describe("Stripe Customer ID (cus_...)"),
+        }),
+        execute: async ({
+          stripe_customer_id,
+        }: {
+          stripe_customer_id: string;
+        }) => {
+          const result = await getDefaultPaymentMethod(stripe_customer_id);
+          if (!result.valid) {
+            return {
+              success: true,
+              has_payment_method: false,
+              message: result.reason,
+            };
+          }
+          return {
+            success: true,
+            has_payment_method: true,
+            card: result.card
+              ? {
+                  brand: result.card.brand,
+                  last4: result.card.last4,
+                  exp_month: result.card.exp_month,
+                  exp_year: result.card.exp_year,
+                }
+              : null,
           };
         },
       },

--- a/src/app/api/stripe/payment-status/route.ts
+++ b/src/app/api/stripe/payment-status/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/auth";
+import { stripe } from "@/lib/stripe";
+
+export async function GET(req: NextRequest) {
+  const user = await authenticateRequest(req.headers.get("authorization"));
+  if (!user) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const customerId = req.nextUrl.searchParams.get("customer_id");
+  if (!customerId) {
+    return NextResponse.json(
+      { success: false, error: "customer_id is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const paymentMethods = await stripe.paymentMethods.list({
+      customer: customerId,
+      type: "card",
+    });
+
+    const hasCard = paymentMethods.data.length > 0;
+    const card = hasCard ? paymentMethods.data[0].card : null;
+
+    return NextResponse.json({
+      success: true,
+      has_payment_method: hasCard,
+      card_summary: card
+        ? {
+            brand: card.brand,
+            last4: card.last4,
+            exp_month: card.exp_month,
+            exp_year: card.exp_year,
+          }
+        : null,
+    });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to check payment status";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/stripe/setup/route.ts
+++ b/src/app/api/stripe/setup/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from "next/server";
+import { authenticateRequest } from "@/lib/auth";
+import { createSetupSession } from "@/lib/stripe";
+
+export async function POST(req: NextRequest) {
+  const user = await authenticateRequest(req.headers.get("authorization"));
+  if (!user) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const origin = req.headers.get("origin") ?? "http://localhost:3000";
+    const checkoutUrl = await createSetupSession(user.sub, `${origin}/`);
+
+    return NextResponse.json({ success: true, url: checkoutUrl });
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "Failed to create setup session";
+    return NextResponse.json(
+      { success: false, error: message },
+      { status: 500 }
+    );
+  }
+}

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -4,6 +4,14 @@ import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import { useState, useRef, useEffect, useLayoutEffect, useMemo, useCallback, FormEvent } from "react";
 import { useLogin3Auth } from "@/contexts/Login3AuthContext";
+import { loadStripe } from "@stripe/stripe-js";
+
+interface CardSummary {
+  brand: string;
+  last4: string;
+  exp_month: number;
+  exp_year: number;
+}
 
 interface ChatViewProps {
   onRefreshBalance: () => void;
@@ -27,17 +35,104 @@ export default function ChatView({
   const scrollRef = useRef<HTMLDivElement>(null);
   const [input, setInput] = useState("");
 
+  // Stripe state
+  const [stripeCustomerId, setStripeCustomerId] = useState<string | null>(null);
+  const [cardInfo, setCardInfo] = useState<CardSummary | null>(null);
+  const [setupLoading, setSetupLoading] = useState(false);
+
   // Keep refs so the transport body/headers always have latest data
   const connectedRef = useRef(connectedAddress);
   const idTokenRef = useRef(idToken);
+  const stripeCustomerIdRef = useRef(stripeCustomerId);
 
   // Update refs in useLayoutEffect to avoid lint errors about accessing refs during render
   useLayoutEffect(() => {
     connectedRef.current = connectedAddress;
     idTokenRef.current = idToken;
-  }, [connectedAddress, idToken]);
+    stripeCustomerIdRef.current = stripeCustomerId;
+  }, [connectedAddress, idToken, stripeCustomerId]);
 
-  /* eslint-disable react-hooks/refs -- refs are accessed in a lazy callback (body/headers function), not during render */
+  // Fetch card info from Stripe
+  const fetchCardInfo = useCallback(async (customerId: string) => {
+    if (!idTokenRef.current) return;
+    try {
+      const res = await fetch(
+        `/api/stripe/payment-status?customer_id=${encodeURIComponent(customerId)}`,
+        { headers: { Authorization: `Bearer ${idTokenRef.current}` } }
+      );
+      const json = await res.json();
+      if (json.has_payment_method && json.card_summary) {
+        setCardInfo(json.card_summary);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Handle Stripe setup redirect on mount
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const setupResult = params.get("stripe_setup");
+    const customerId = params.get("customer_id");
+
+    if (setupResult === "success" && customerId) {
+      localStorage.setItem("stripe_customer_id", customerId);
+      setStripeCustomerId(customerId);
+      window.history.replaceState({}, "", "/");
+      fetchCardInfo(customerId);
+    } else {
+      const saved = localStorage.getItem("stripe_customer_id");
+      if (saved) {
+        setStripeCustomerId(saved);
+        fetchCardInfo(saved);
+      }
+    }
+  }, [fetchCardInfo]);
+
+  // Handle "Add Card" click
+  const handleAddCard = async () => {
+    if (!idToken || setupLoading) return;
+    setSetupLoading(true);
+    try {
+      const res = await fetch("/api/stripe/setup", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${idToken}`,
+        },
+      });
+      const json = await res.json();
+      if (json.success && json.url) {
+        window.location.href = json.url;
+      }
+    } catch {
+      // ignore
+    } finally {
+      setSetupLoading(false);
+    }
+  };
+
+  // Handle 3DS popup
+  const handle3DS = useCallback(async (clientSecret: string, paymentIntentId: string) => {
+    const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+    if (!publishableKey) return;
+
+    const stripeJs = await loadStripe(publishableKey);
+    if (!stripeJs) return;
+
+    const { error } = await stripeJs.handleCardAction(clientSecret);
+    if (error) {
+      sendMessage({
+        text: `3D Secure authentication failed: ${error.message}. The payment was not completed.`,
+      });
+    } else {
+      sendMessage({
+        text: `3D Secure authentication complete. Please verify the payment with intent ID: ${paymentIntentId}`,
+      });
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const transport = useMemo(
     () =>
       new DefaultChatTransport({
@@ -48,11 +143,11 @@ export default function ChatView({
         }),
         body: () => ({
           connectedAddress: connectedRef.current,
+          stripeCustomerId: stripeCustomerIdRef.current ?? undefined,
         }),
       }),
     []
   );
-  /* eslint-enable react-hooks/refs */
 
   const { messages, sendMessage, status, error } = useChat({ transport });
 
@@ -69,18 +164,30 @@ export default function ChatView({
   const processedToolsRef = useRef<Set<string>>(new Set());
 
   const handleToolOutput = useCallback(
-    (toolKey: string, toolName: string) => {
+    (toolKey: string, toolName: string, output: unknown) => {
       if (processedToolsRef.current.has(toolKey)) return;
       processedToolsRef.current.add(toolKey);
 
       if (toolName === "check_balance" || toolName === "request_faucet" || toolName === "send_payment" || toolName === "buy_product") {
         onRefreshBalance();
       }
+
+      // Handle 3DS requirement from buy_with_stripe
+      if (toolName === "buy_with_stripe" && output && typeof output === "object") {
+        const data = output as Record<string, unknown>;
+        if (
+          data.requires_stripe_action &&
+          typeof data.client_secret === "string" &&
+          typeof data.payment_intent_id === "string"
+        ) {
+          handle3DS(data.client_secret, data.payment_intent_id);
+        }
+      }
     },
-    [onRefreshBalance]
+    [onRefreshBalance, handle3DS]
   );
 
-  // Sync balance refreshes from tool calls
+  // Sync balance refreshes and 3DS from tool calls
   useEffect(() => {
     for (const msg of messages) {
       if (msg.role !== "assistant" || !msg.parts) continue;
@@ -91,7 +198,7 @@ export default function ChatView({
 
         if (p.state === "output-available") {
           const toolKey = `${msg.id}-${toolName}-${p.toolCallId ?? ""}`;
-          handleToolOutput(toolKey, toolName);
+          handleToolOutput(toolKey, toolName, p.output);
         }
       }
     }
@@ -130,6 +237,37 @@ export default function ChatView({
             <p className="text-xs mb-6" style={{ color: "var(--text-tertiary)" }}>
               Your AI payment assistant on Base Sepolia
             </p>
+
+            {/* Stripe card info */}
+            {cardInfo && (
+              <div
+                data-testid="card-info"
+                className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg mb-4 text-xs"
+                style={{ background: "var(--bg-secondary)", border: "1px solid var(--border)", color: "var(--text-secondary)" }}
+              >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="1" y="4" width="22" height="16" rx="2" ry="2" />
+                  <line x1="1" y1="10" x2="23" y2="10" />
+                </svg>
+                {cardInfo.brand} ****{cardInfo.last4}
+              </div>
+            )}
+
+            {/* Add Card button */}
+            {!cardInfo && (
+              <button
+                data-testid="add-card-button"
+                onClick={handleAddCard}
+                disabled={setupLoading}
+                className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-lg mb-4 text-xs transition-opacity hover:opacity-80 disabled:opacity-50"
+                style={{ background: "var(--bg-secondary)", border: "1px solid var(--border)", color: "var(--text-secondary)" }}
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                  <line x1="12" y1="5" x2="12" y2="19" /><line x1="5" y1="12" x2="19" y2="12" />
+                </svg>
+                {setupLoading ? "Redirecting..." : "+ Add Card"}
+              </button>
+            )}
 
             {/* Quick Actions */}
             <div className="space-y-2 max-w-xs mx-auto">

--- a/src/lib/stripe.ts
+++ b/src/lib/stripe.ts
@@ -1,0 +1,226 @@
+import Stripe from "stripe";
+
+function getStripeClient(): Stripe {
+  if (!process.env.STRIPE_SECRET_KEY) {
+    throw new Error("Missing STRIPE_SECRET_KEY environment variable");
+  }
+  return new Stripe(process.env.STRIPE_SECRET_KEY, {
+    httpClient: Stripe.createFetchHttpClient(),
+  });
+}
+
+/** Lazy Stripe client — only created when first accessed */
+export const stripe = new Proxy({} as Stripe, {
+  get(_target, prop) {
+    const client = getStripeClient();
+    const value = (client as unknown as Record<string | symbol, unknown>)[prop];
+    return typeof value === "function" ? value.bind(client) : value;
+  },
+});
+
+// ──────────────────────────────────────────────
+// Product catalog
+// ──────────────────────────────────────────────
+
+export const STRIPE_PRODUCT = {
+  name: "Premium AI Market Report",
+  description: "AI-generated market analysis with real-time insights",
+  price_cents: 100, // $1.00 USD
+  currency: "usd",
+};
+
+// ──────────────────────────────────────────────
+// Customer & payment method helpers
+// ──────────────────────────────────────────────
+
+export async function findOrCreateCustomer(userId: string): Promise<string> {
+  const existing = await stripe.customers.search({
+    query: `metadata["app_user_id"]:"${userId}"`,
+    limit: 1,
+  });
+
+  if (existing.data.length > 0) {
+    return existing.data[0].id;
+  }
+
+  const customer = await stripe.customers.create({
+    metadata: { app_user_id: userId },
+  });
+  return customer.id;
+}
+
+export async function getDefaultPaymentMethod(
+  customerId: string
+): Promise<{
+  valid: boolean;
+  payment_method_id?: string;
+  card?: Stripe.PaymentMethod.Card;
+  reason?: string;
+}> {
+  const paymentMethods = await stripe.paymentMethods.list({
+    customer: customerId,
+    type: "card",
+  });
+
+  if (paymentMethods.data.length === 0) {
+    return {
+      valid: false,
+      reason:
+        "No payment method on file. Please click the '+ Add Card' button to set up your card.",
+    };
+  }
+
+  const pm = paymentMethods.data[0];
+  return { valid: true, payment_method_id: pm.id, card: pm.card ?? undefined };
+}
+
+// ──────────────────────────────────────────────
+// Setup session (one-time card registration)
+// ──────────────────────────────────────────────
+
+export async function createSetupSession(
+  userId: string,
+  returnUrl: string
+): Promise<string> {
+  const customerId = await findOrCreateCustomer(userId);
+
+  const session = await stripe.checkout.sessions.create({
+    mode: "setup",
+    customer: customerId,
+    payment_method_types: ["card"],
+    success_url: `${returnUrl}?stripe_setup=success&customer_id=${customerId}`,
+    cancel_url: `${returnUrl}?stripe_setup=cancelled`,
+  });
+
+  return session.url!;
+}
+
+// ──────────────────────────────────────────────
+// Off-session charge (autonomous payment)
+// ──────────────────────────────────────────────
+
+export type ChargeResult =
+  | { success: true; payment_intent_id: string }
+  | {
+      success: false;
+      requires_3ds: true;
+      payment_intent_id: string;
+      client_secret: string;
+      reason: string;
+    }
+  | { success: false; requires_3ds?: false; reason: string };
+
+export async function chargeCustomer(
+  customerId: string,
+  amountCents: number,
+  description: string
+): Promise<ChargeResult> {
+  const {
+    valid,
+    payment_method_id,
+    reason: pmReason,
+  } = await getDefaultPaymentMethod(customerId);
+  if (!valid || !payment_method_id) {
+    return { success: false, reason: pmReason! };
+  }
+
+  try {
+    const paymentIntent = await stripe.paymentIntents.create({
+      amount: amountCents,
+      currency: STRIPE_PRODUCT.currency,
+      customer: customerId,
+      payment_method: payment_method_id,
+      description,
+      confirm: true,
+      off_session: true,
+    });
+
+    if (paymentIntent.status === "succeeded") {
+      return { success: true, payment_intent_id: paymentIntent.id };
+    }
+
+    if (
+      paymentIntent.status === "requires_action" &&
+      paymentIntent.client_secret
+    ) {
+      return {
+        success: false,
+        requires_3ds: true,
+        payment_intent_id: paymentIntent.id,
+        client_secret: paymentIntent.client_secret,
+        reason:
+          "This card requires 3D Secure authentication. A popup will appear for you to complete.",
+      };
+    }
+
+    return {
+      success: false,
+      reason: `Payment ended with status: ${paymentIntent.status}`,
+    };
+  } catch (err) {
+    if (err instanceof Stripe.errors.StripeCardError) {
+      if (
+        err.code === "authentication_required" &&
+        err.payment_intent?.client_secret
+      ) {
+        return {
+          success: false,
+          requires_3ds: true,
+          payment_intent_id: err.payment_intent.id,
+          client_secret: err.payment_intent.client_secret,
+          reason:
+            "This card requires 3D Secure authentication. A popup will appear for you to complete.",
+        };
+      }
+      return { success: false, reason: err.message };
+    }
+    const message =
+      err instanceof Error ? err.message : "Unknown payment error";
+    return { success: false, reason: message };
+  }
+}
+
+// ──────────────────────────────────────────────
+// Verify payment after 3DS popup
+// ──────────────────────────────────────────────
+
+export async function verifyPaymentIntent(
+  paymentIntentId: string
+): Promise<{ success: boolean; reason?: string }> {
+  const pi = await stripe.paymentIntents.retrieve(paymentIntentId);
+
+  if (pi.status === "succeeded") return { success: true };
+
+  return {
+    success: false,
+    reason: `Payment status is "${pi.status}". Authentication may not be complete yet.`,
+  };
+}
+
+// ──────────────────────────────────────────────
+// Product builder
+// ──────────────────────────────────────────────
+
+export function buildStripeProduct(
+  paymentIntentId: string,
+  amountCents: number
+) {
+  return {
+    product: STRIPE_PRODUCT.name,
+    data: {
+      report_id: `RPT-${paymentIntentId.slice(-8).toUpperCase()}`,
+      title: "AI Market Analysis Report",
+      executive_summary:
+        "Strong bullish momentum detected across tech and DeFi sectors.",
+      key_findings: [
+        "AI infrastructure spending up 42% YoY",
+        "Base ecosystem TVL growing at record pace",
+        "Consumer sentiment index at 6-month high",
+        "Stablecoin transfer volumes exceeded $1T this quarter",
+      ],
+      generated_at: new Date().toISOString(),
+      payment_intent_id: paymentIntentId,
+      amount_charged: `$${(amountCents / 100).toFixed(2)} USD`,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds full Stripe card payment integration with off-session autonomous charging
- Implements 3D Secure popup handling via `@stripe/stripe-js`
- Creates 3 new agent tools: `buy_with_stripe`, `verify_stripe_payment`, `stripe_check_setup`
- Card registration via Stripe Checkout (setup mode), card info display in chat UI

## Files changed
- `src/lib/stripe.ts` — Lazy Stripe client, customer CRUD, off-session charge with 3DS detection, payment verification, product builder
- `src/app/api/stripe/setup/route.ts` — POST endpoint for card registration session
- `src/app/api/stripe/payment-status/route.ts` — GET endpoint for saved card info
- `src/app/api/chat/route.ts` — 3 new Stripe tools, `stripeCustomerId` in body, Stripe context in system prompt
- `src/components/ChatView.tsx` — "+ Add Card" button, card info display, 3DS popup via `loadStripe`, `stripeCustomerId` in localStorage
- `e2e/fixtures/api-mocks.ts` — Stripe API mocks
- `e2e/fixtures/chat-mock.ts` — `buyWithStripeStream` scenario
- `e2e/tests/12-chat-buy-stripe.spec.ts` — 3 E2E tests
- `package.json` — Added `stripe` and `@stripe/stripe-js` dependencies

## Environment variables required
```
STRIPE_SECRET_KEY=sk_test_...
NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_...
```

## Test plan
- [x] `pnpm tsc --noEmit` — passes
- [x] `pnpm lint` — passes
- [x] `pnpm test` — 21 unit tests pass
- [x] `pnpm test:e2e` — 29 E2E tests pass (3 new Stripe tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)